### PR TITLE
Rename privacy info

### DIFF
--- a/content/en/docs/project-info/privacy-information.md
+++ b/content/en/docs/project-info/privacy-information.md
@@ -1,5 +1,5 @@
 ---
-title: "Data Protection Notice"
+title: "Privacy Information"
 date: 2022-05-09T14:24:56+05:30
 weight: 9
 ---


### PR DESCRIPTION
The document shall not be called "Data Protection Notice", as this term is used for a different type of document.
The project's data privacy consultant suggested to use the title "Privac Information" or "Customer Leaflet" for this document.