### PR TITLE
Update Kanto-auto-deployer documentation

### DIFF
--- a/content/en/docs/build/dev-and-maintenance/rust/kanto-auto-deployer.md
+++ b/content/en/docs/build/dev-and-maintenance/rust/kanto-auto-deployer.md
@@ -1,23 +1,41 @@
 ---
-title: "Kanto Auto deployer"
+title: "Kanto Auto deployer (KAD)"
 date: 2023-01-03T17:24:56+05:30
 weight: 2
 ---
 
 **TLDR**: To deploy a container in the final Leda image, all you generally need to do is add the manifest in the [kanto-containers](https://github.com/eclipse-leda/meta-leda/tree/main/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers) directory and re-build.
 
-Kanto-CM does not provide (currently) an out-of-the box feature that allows for the automatic deployment of containers through manifest files similar to k3s' automated deployment of k8s-manifests found in the `/var/lib/rancher/k3s/server/manifests` directory.
+Kanto-CM does not provide (currently) a _stable_ feature that allows for the automatic deployment of containers through manifest files similar to k3s' automated deployment of k8s-manifests found in the `/var/lib/rancher/k3s/server/manifests` directory.
 
 This can be worked around via a bash script for each container that runs on boot and makes sure it's deployed. Even though this approach is functional it is not very structured and would require a lot repeating code.
 
 That is why the "[Kanto Auto deployer](https://github.com/eclipse-leda/leda-utils/tree/main/src/rust/kanto-auto-deployer)" tool was developed. It directly implements the ideas in [Communicating with Кanto-CM via gRPC](../notes-on-kanto-grpc).
 
 The compiled binary takes a path to a directory containing the json manifests, parses them into Rust structures and sends gRPC requests to kanto container management to deploy these containers.
-If the container is already deployed the manifest is ignored.
+
+
 
 ## Manifest structure
 
-Kanto auto deployer uses the exact same structure for its manifests as the internal representation of container state in kanto container management. For example:
+Because Kanto CM uses different JSON formats for the interal state representation of the container (from the gRPC API) and for the deployment via the Container Management-native `init_dir`-mechanism, KAD supports both through the "manifests_parser" module.
+The conversion between formats is automatic (logged as a warning when it's attempted)
+ so you **do not** need to provide extra options when using one or the other.
+
+### Container Management Manifests Format
+
+This is the CM-native format, described in the [Kanto-CM documentation](https://websites.eclipseprojects.io/kanto/docs/references/containers/container-config/#template). 
+It is the **recommended** format since KAD is supposed to be replaced by native CM deployment modules in the future and this manifest 
+format will be compatible with that.
+
+It also allows you to ommit options (defaults will be used). KAD will issue a log warning when the "manifests_parser" attempts to convert this manifest format
+to the gRPC message format (internal state representation).
+
+### Internal State Representation
+
+The KAD "native" manifests format uses the exact same structure for its manifests as the internal representation of container state in kanto container management. 
+This manifest format **does not** allow keys in the json to be ommited, so these manifests are generally larger/noisier.
+For example:
 
 ```json
 {
@@ -110,10 +128,18 @@ For example, you do not need to specify the container "id" in the manifest, as a
 
 ## Container deployment in Leda
 
-Kanto-auto-deployer runs as a one-shot service on boot that goes through the manifest folder (default: `/var/containers/manifests`) and deploys required containers.
+Kanto-auto-deployer can run as a one-shot util that goes through the manifest folder (default: `/data/var/containers/manifests`) and deploys required containers.
+
+When you pass the `--daemon` flag it would enable the "filewatcher" module that would continously monitor the provided path for changes/creation of manifests.
 
 The Bitbake recipe for building and installing the auto deployer service can be found at [kanto-auto-deployer_git.bb](https://github.com/eclipse-leda/meta-leda/blob/main/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb). 
 
 This recipe also takes all manifests in the [kanto-containers](https://github.com/eclipse-leda/meta-leda/tree/main/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers) directory and installs them in the directory specified by the `KANTO_MANIFESTS_DIR` BitBake variable (weak default: `/var/containers/manifests`).
 
 **Important**: To deploy a container in the final Leda image, all you generally need to do is add the manifest in the [kanto-containers](https://github.com/eclipse-leda/meta-leda/tree/main/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers) directory and re-build.
+
+## Conditional compilation of the filewatcher module
+
+To reduce binary bloat the `--daemon` option is namespaced under the `filewatcher` conditonal compilation flag (enabled by default). To compile KAD without the filewatcher module run: `cargo build --release --no-default-features`.
+(Implemented in [Leda Utils PR#35](https://github.com/eclipse-leda/leda-utils/pull/35))
+

--- a/content/en/docs/build/dev-and-maintenance/rust/kanto-auto-deployer.md
+++ b/content/en/docs/build/dev-and-maintenance/rust/kanto-auto-deployer.md
@@ -130,7 +130,7 @@ For example, you do not need to specify the container "id" in the manifest, as a
 
 Kanto-auto-deployer can run as a one-shot util that goes through the manifest folder (default: `/data/var/containers/manifests`) and deploys required containers.
 
-When you pass the `--daemon` flag it would enable the "filewatcher" module that would continously monitor the provided path for changes/creation of manifests.
+When you pass the `--daemon` flag it would enable the "filewatcher" module that would continuously monitor the provided path for changes/creation of manifests.
 
 The Bitbake recipe for building and installing the auto deployer service can be found at [kanto-auto-deployer_git.bb](https://github.com/eclipse-leda/meta-leda/blob/main/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb). 
 

--- a/content/en/docs/build/dev-and-maintenance/rust/kanto-auto-deployer.md
+++ b/content/en/docs/build/dev-and-maintenance/rust/kanto-auto-deployer.md
@@ -140,6 +140,7 @@ This recipe also takes all manifests in the [kanto-containers](https://github.co
 
 ## Conditional compilation of the filewatcher module
 
-To reduce binary bloat the `--daemon` option is namespaced under the `filewatcher` conditonal compilation flag (enabled by default). To compile KAD without the filewatcher module run: `cargo build --release --no-default-features`.
+To reduce binary bloat the `--daemon` option is namespaced under the `filewatcher` conditional compilation flag (enabled by default).
+To compile KAD without the filewatcher module run: `cargo build --release --no-default-features`.
 (Implemented in [Leda Utils PR#35](https://github.com/eclipse-leda/leda-utils/pull/35))
 

--- a/content/en/docs/customization/deploying-containers/_index.md
+++ b/content/en/docs/customization/deploying-containers/_index.md
@@ -4,24 +4,22 @@ date: 2023-01-03T17:24:56+05:30
 weight: 2
 ---
 
-## Kanto Container Management (kanto-cm) init-dir
 
-Kanto-cm provides a mechanism to automatically deploy containers based on json-manifests stored in a so-called `init_dir` on boot. The template can be found in the kanto-cm documentation: [Template](https://websites.eclipseprojects.io/kanto/docs/references/containers/container-manager-config/#template).
+## Kanto-auto-deployer (KAD)
 
-A "filled in" template can be found in meta-leda (e.g. meta [meta-leda/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core/databroker.json](https://github.com/eclipse-leda/meta-leda/blob/2cb683a9606c01a73fc4f4d01df92a23a2cd2b9c/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core/databroker.json)).
+This service has been implemented as a stopgap solution by the Leda team until the Kanto Container Managament deployment of containers from manifests is stabilized.
 
-The directory for these manifests is set during image build time through the BitBake variable `KANTO_MANIFESTS_DIR`. By default, the Leda Quickstart image sets this directory to `/data/var/containers/manifests`. Since this is a directory mounted on the persistent **data**-partition you can add custom manifests/customize the default ones after an image has been built. These changes **will not be affected** by a RAUC update.
+In-depth documentation on its operation and development can be found in [Kanto Auto deployer](../../build/dev-and-maintenance/rust/kanto-auto-deployer). 
 
-A standard set of containers is deployed with meta-leda, the manifests for which can be found in `meta-leda/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core` and `meta-leda/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/`.
+In the Leda Distro KAD runs as a service that continously monitors the directory defined with the BitBake variable `KANTO_MANIFESTS_DEV_DIR` in the distro config recipes. By default, the Leda quickstart images use `KANTO_MANIFESTS_DEV_DIR=/data/var/containers/manifests"`. So, these manifests are again stored in the persistent **data**-partition and can be modified after the image has been deployed.
 
-**Important: The manifests in the kanto-cm init-dir are checked only _ONCE_  - on service start-up. If you add/change a manifest you would need to restart the whole "container-management" service for your changes to take effect.**
+**Important: KAD supports the [Kanto Container Management Manifest Template](https://websites.eclipseprojects.io/kanto/docs/references/containers/container-config/#template) 
+AND the [Container Internal State Representation](../../build/dev-and-maintenance/rust/kanto-auto-deployer//#internal-state-representation). For future compatiblity reasons it is recommended that you choose [Kanto Container Management Manifest Template](https://websites.eclipseprojects.io/kanto/docs/references/containers/container-config/#template).** 
 
-## Kanto-auto-deployer
+A standard set of containers is deployed through meta-leda, the manifests for which can be found in `meta-leda/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core` and `meta-leda/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example`.  
 
-This service has been implemented as a stopgap solution by the Leda team before the kanto-cm init-dir mechanism was implemented by the Kanto team. In-depth documentation on its operation and development can be found in the [Kanto Auto deployer](../../build/dev-and-maintenance/rust/kanto-auto-deployer). This runs as a one-shot service on boot and checks the directory defined in the BitBake variable `KANTO_MANIFESTS_DEV_DIR` in the distro config recipes. By default, the Leda quickstart images use `KANTO_MANIFESTS_DEV_DIR=/data/var/containers/manifests_dev"`. So, these manifest are again stored in the persistent **data**-partition and can be modified after the image has been deployed.
+The advantage of this service is that it can be restarted very quickly (`systemctl restart kanto-auto-deployer`), without having to restart the _whole_ container-management service. The implemented filewatcher (the `--daemon` flag) allows you to quickly create/edit  (or even `touch` them) container manifests on the device that would be on-the-fly deployed after saving. This allows for rapid testing when creating new container manifests.
 
-**Important: the [manifest template](../../build/dev-and-maintenance/rust/kanto-auto-deployer#manifest-structure) used for this service is similar to the one for the kanto-cm native mechanism, but is, in fact, different. Kanto-auto-deployer uses the kanto-cm internal state representation.**
+## Kanto Container Management init-dir
 
-A standard set of _dev_-containers is deployed with meta-leda, the manifests for which can be found in `meta-leda/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core_dev` and `meta-leda/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example_dev/`.
-
-The advantage of this service is that it can be restarted very quickly (`systemctl restart kanto-auto-deployer`), without having to restart the _whole_ container-management service. This allows for rapid testing when deploying a new container. Due to the similarity of both manifests, the kanto-auto-deployer-style manifest can later be easily migrated to the kanto ini-dir style-one.
+This feature of Kanto Container Managament by the Kanto Teams is currently under development and hence unstable. That is why it is not used as of the test-0.0.6 release of Leda Distro and 0.1.0-M1 release of meta-leda.

--- a/content/en/docs/customization/deploying-containers/_index.md
+++ b/content/en/docs/customization/deploying-containers/_index.md
@@ -7,11 +7,14 @@ weight: 2
 
 ## Kanto-auto-deployer (KAD)
 
-This service has been implemented as a stopgap solution by the Leda team until the Kanto Container Managament deployment of containers from manifests is stabilized.
+This service has been implemented as a stopgap solution by the Leda team since as of now the Kanto CM-native mechanism
+for initial container deployment does not suit the needs of the Leda Quickstart image well.
 
-In-depth documentation on its operation and development can be found in [Kanto Auto deployer](../../build/dev-and-maintenance/rust/kanto-auto-deployer). 
+In-depth documentation on its operation and development can be found in [Kanto Auto deployer](../../build/dev-and-maintenance/rust/kanto-auto-deployer).
 
-In the Leda Distro KAD runs as a service that continously monitors the directory defined with the BitBake variable `KANTO_MANIFESTS_DEV_DIR` in the distro config recipes. By default, the Leda quickstart images use `KANTO_MANIFESTS_DEV_DIR=/data/var/containers/manifests"`. So, these manifests are again stored in the persistent **data**-partition and can be modified after the image has been deployed.
+In the Leda Distro KAD runs as a service that continuously monitors the directory defined with the BitBake variable `KANTO_MANIFESTS_DEV_DIR` in the distro config recipes.
+By default, the Leda quickstart images use `KANTO_MANIFESTS_DEV_DIR=/data/var/containers/manifests"`.
+So, these manifests are again stored in the persistent **data**-partition and can be modified after the image has been deployed.
 
 **Important: KAD supports the [Kanto Container Management Manifest Template](https://websites.eclipseprojects.io/kanto/docs/references/containers/container-config/#template) 
 AND the [Container Internal State Representation](../../build/dev-and-maintenance/rust/kanto-auto-deployer//#internal-state-representation). For future compatiblity reasons it is recommended that you choose [Kanto Container Management Manifest Template](https://websites.eclipseprojects.io/kanto/docs/references/containers/container-config/#template).** 

--- a/content/en/docs/general-usage/utilities/kanto-auto-deployer.md
+++ b/content/en/docs/general-usage/utilities/kanto-auto-deployer.md
@@ -59,7 +59,7 @@ root@qemux86-64:~# kanto-auto-deployer /data/var/containers/manifests/
 ## Usage as systemd service
 
 In the Leda quickstart images, kanto-auto-deployer is installed as a systemd service. 
-> Note the service uses the `--daemon` flag that asks KAD to continously monitor the specified directory (see last line of logs).
+> Note the service uses the `--daemon` flag that asks KAD to continuously monitor the specified directory (see last line of logs).
 
 The service unit configuration file is located in `/lib/systemd/system/kanto-auto-deployer.service`:
 

--- a/content/en/docs/general-usage/utilities/kanto-auto-deployer.md
+++ b/content/en/docs/general-usage/utilities/kanto-auto-deployer.md
@@ -1,45 +1,66 @@
 ---
-title: "Kanto Auto Deployer"
+title: "Kanto Auto Deployer (KAD)"
 date: 2022-05-09T14:24:56+05:30
 weight: 7
 ---
 
 Automatically deploys containers to the Kanto Container Management based on deployment descriptors from a given path.
 All deployment descriptors in the manifests folder will be deployed (created and started) on startup of the service.
-
-> Note: The Kanto-CM and Kanto-Auto-Deployer container manifest descriptors (json) formats are incompatible and differ slightly in their structure!
+The directory will then be monitored for creation of/changes to manfiests and those changes will be redeployed.
 
 ## Usage
 
 Usage:
 
 ```shell
-root@qemux86-64:~# kanto-auto-deployer --help
+$ kanto-auto-deployer --help
+kanto-auto-deployer 0.2.0
+Automated deployment of Kanto Container Management Manifests
+
 USAGE:
-  kanto-auto-deployer [PATH TO MANIFESTS FOLDER]
+    kanto-auto-deployer [OPTIONS] [MANIFESTS_PATH]
+
+ARGS:
+    <MANIFESTS_PATH>    Set the path to the directory containing the manifests [default: .]
+
+OPTIONS:
+    -d, --daemon                   Run as a daemon that continuously monitors the provided path for
+                                   changes
+    -h, --help                     Print help information
+    -s, --socket-cm <SOCKET_CM>    Set the path to the Kanto Container Management API socket
+                                   [default: /run/container-management/container-management.sock]
+    -V, --version                  Print version information
 ```
 
 Example:
 
 ```shell
 # Use container manifests from current working directory
-/var/containers/manifests_dev/ $ kanto-auto-deployer
-Reading manifests from [.]
-Already exists [cloudconnector]
-Already exists [otelcollector]
-Already exists [seatservice-example]
+root@qemux86-64:/data/var/containers/manifests# kanto-auto-deployer 
+[2023-04-18T10:27:21Z INFO  kanto_auto_deployer] Running initial deployment of "/data/var/containers/manifests"
+[2023-04-18T10:27:21Z INFO  kanto_auto_deployer] Reading manifests from [/data/var/containers/manifests]
+[2023-04-18T10:27:21Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
+[2023-04-18T10:27:21Z INFO  kanto_auto_deployer] Already exists [cloudconnector]
+[2023-04-18T10:27:21Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
+[2023-04-18T10:27:21Z INFO  kanto_auto_deployer] Already exists [databroker]
 
 # Use container manifests from specified directory
-~ $ kanto-auto-deployer /var/containers/manifests_dev/
-Reading manifests from [/data/var/containers/manifests_dev/]
-Already exists [cloudconnector]
-Already exists [otelcollector]
-Already exists [seatservice-example]
+root@qemux86-64:~# kanto-auto-deployer /data/var/containers/manifests/
+[2023-04-18T10:27:44Z INFO  kanto_auto_deployer] Running initial deployment of "/data/var/containers/manifests"
+[2023-04-18T10:27:44Z INFO  kanto_auto_deployer] Reading manifests from [/data/var/containers/manifests]
+[2023-04-18T10:27:44Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
+[2023-04-18T10:27:44Z INFO  kanto_auto_deployer] Already exists [cloudconnector]
+[2023-04-18T10:27:44Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
+[2023-04-18T10:27:44Z INFO  kanto_auto_deployer] Already exists [databroker]
 ```
+
+> Nоte: The warnings from the manifest_parser module are normal and expected when the manifest is in the [Container Management Manifests Format](https://websites.eclipseprojects.io/kanto/docs/references/containers/container-config/#template)
 
 ## Usage as systemd service
 
-In the Leda quickstart images, kanto-auto-deployer is installed as a systemd service.
+In the Leda quickstart images, kanto-auto-deployer is installed as a systemd service. 
+> Note the service uses the `--daemon` flag that asks KAD to continously monitor the specified directory (see last line of logs).
+
 The service unit configuration file is located in `/lib/systemd/system/kanto-auto-deployer.service`:
 
 ```shell
@@ -55,7 +76,7 @@ WantedBy=multi-user.target
 [Service]
 Restart=on-failure
 RestartSec=5s
-ExecStart=/usr/bin/kanto-auto-deployer /data/var/containers/manifests_dev
+ExecStart=/usr/bin/kanto-auto-deployer /data/var/containers/manifests --daemon
 ```
 
 Example output:
@@ -64,14 +85,21 @@ Example output:
 root@qemux86-64:/lib/systemd/system# systemctl status kanto-auto-deployer.service 
 * kanto-auto-deployer.service - Kanto Auto Deployer
      Loaded: loaded (/lib/systemd/system/kanto-auto-deployer.service; enabled; vendor preset: enabled)
-     Active: inactive (dead) since Fri 2022-12-09 09:41:42 UTC; 7min ago
-    Process: 472 ExecStart=/usr/bin/kanto-auto-deployer /var/containers/manifests (code=exited, status=0/SUCCESS)
-   Main PID: 472 (code=exited, status=0/SUCCESS)
+     Active: active (running) since Tue 2023-04-18 10:22:10 UTC; 3min 55s ago
+   Main PID: 525 (kanto-auto-depl)
+      Tasks: 10 (limit: 4708)
+     Memory: 1.4M
+     CGroup: /system.slice/kanto-auto-deployer.service
+             `- 525 /usr/bin/kanto-auto-deployer /data/var/containers/manifests --daemon
 
-Dec 09 09:41:33 qemux86-64 systemd[1]: Started Kanto Auto Deployer.
-Dec 09 09:41:33 qemux86-64 kanto-auto-deployer[472]: Creating [databroker]
-Dec 09 09:41:41 qemux86-64 kanto-auto-deployer[472]: Created [databroker]
-Dec 09 09:41:41 qemux86-64 kanto-auto-deployer[472]: Starting [databroker]
-Dec 09 09:41:42 qemux86-64 kanto-auto-deployer[472]: Started [databroker]
-Dec 09 09:41:42 qemux86-64 systemd[1]: kanto-auto-deployer.service: Deactivated successfully.
+Apr 18 10:22:48 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:22:48Z INFO  kanto_auto_deployer] Creating [sua]
+Apr 18 10:23:04 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:04Z INFO  kanto_auto_deployer] Created [sua]
+Apr 18 10:23:04 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:04Z INFO  kanto_auto_deployer] Starting [sua]
+Apr 18 10:23:05 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:05Z INFO  kanto_auto_deployer] Started [sua]
+Apr 18 10:23:05 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:05Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
+Apr 18 10:23:05 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:05Z INFO  kanto_auto_deployer] Creating [vum]
+Apr 18 10:23:10 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:10Z INFO  kanto_auto_deployer] Created [vum]
+Apr 18 10:23:10 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:10Z INFO  kanto_auto_deployer] Starting [vum]
+Apr 18 10:23:11 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:11Z INFO  kanto_auto_deployer] Started [vum]
+Apr 18 10:23:11 qemux86-64 kanto-auto-deployer[525]: [2023-04-18T10:23:11Z INFO  kanto_auto_deployer] Running in daemon mode. Continuously monitoring "/data/var/containers/manifests"
 ```

--- a/content/en/docs/general-usage/utilities/kanto-auto-deployer.md
+++ b/content/en/docs/general-usage/utilities/kanto-auto-deployer.md
@@ -6,7 +6,7 @@ weight: 7
 
 Automatically deploys containers to the Kanto Container Management based on deployment descriptors from a given path.
 All deployment descriptors in the manifests folder will be deployed (created and started) on startup of the service.
-The directory will then be monitored for creation of/changes to manfiests and those changes will be redeployed.
+The directory will then be monitored for creation of/changes to manifests and those changes will be redeployed.
 
 ## Usage
 


### PR DESCRIPTION
The KAD documentation has gotten out-of-sync with the current state of the tool (does not mention manifest_parser, the removal of init_dir, etc)
This PR updates those pages to match the 0.1.0-M1 release.